### PR TITLE
Fix a type error in typing.ml and suppress a warning

### DIFF
--- a/OMakefile
+++ b/OMakefile
@@ -115,7 +115,7 @@ OCAMLPACKS[] =
 # Various options
 #
 #OCAMLFLAGS += -g -thread -w A-4-9-40-42-44-45 -warn-error A
-OCAMLFLAGS += -g -thread -w -4-9-26-40-42-44-45
+OCAMLFLAGS += -g -thread -w -3-4-9-26-40-42-44-45
 # OCAMLCFLAGS   +=
 # OCAMLOPTFLAGS +=
 # OCAML_LINK_FLAGS +=

--- a/typing.ml
+++ b/typing.ml
@@ -68,7 +68,7 @@ let rec generalize (ty:Type.t) : Type.t =
 let rec subst (ty:Type.t) (env:(tyvar * t) list) =
   match ty.desc with
   | `Var tyvar ->
-    Option.value (List.Assoc.find env tyvar) ~default:ty
+    Option.value (List.Assoc.find env ~equal:(=) tyvar) ~default:ty
   | `App (`Tyfun (tyvars, ty'), args) ->
     let env' = List.map2_exn tyvars args
         ~f:(fun tyvar ty -> (tyvar, ty)) in


### PR DESCRIPTION
You forgot the ~equal argument of the List.Assoc function, so it could not compile.

I added the warning 3 to the list of warning to ignore, since module Core.Std is deprecated, the warning prevented me to compile the project (and omake forced the -warn-error I don't know why).